### PR TITLE
Fix http status checks

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -24,14 +24,17 @@ processes = []
   protocol = "tcp"
   script_checks = []
 
-  # [[services.http_checks]]
-  #   interval = 10000
-  #   grace_period = "5s"
-  #   method = "get"
-  #   path = "/ping"
-  #   protocol = "http"
-  #   timeout = 2000
-  #   tls_skip_verify = false
+  [[services.http_checks]]
+    interval = 10000
+    grace_period = "5s"
+    method = "get"
+    path = "/ping"
+    protocol = "http"
+    timeout = 2000
+    tls_skip_verify = false
+    [services.http_checks.headers]
+      X-Forwarded-Proto = "https"
+
 
   [services.concurrency]
     hard_limit = 25


### PR DESCRIPTION
As it turns out, my lucky config expects https forwarded for headers otherwise it
will forcibly upgrade the connection to https

By adding the X-Forwarded-For = https header to the http check,
we trick lucky into thinking the connection is https terminated already
and make the http check work over http instead of https
