### PR TITLE
Change auto-merge github action

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,14 +1,21 @@
-name: Auto-merge minor/patch
+name: Auto-merge
+
 on:
-  schedule:
-    - cron: "0 * * * *"
+  workflow_run:
+    types:
+      - completed
+    workflows:
+      - 'Lucky App CI'
+
 jobs:
-  test:
-    name: Auto-merge minor and patch updates
+  auto_merge:
+    name: Auto-merge
     runs-on: ubuntu-latest
     steps:
-      - uses: koj-co/dependabot-pr-action@master
+      - if: ${{ github.event.workflow_run.conclusion == 'success' }}
+        name: Auto-merge
+        uses: ridedott/merge-me-action@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          merge-minor: true
-          merge-patch: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PRESET: DEPENDABOT_MINOR
+          MERGE_METHOD: REBASE


### PR DESCRIPTION
This runs on test success instead of on a schedule so it should be
faster and more reliable

It also has the option to rebase instead of merge, which is something I
feel very strongly about

Overall a good call here